### PR TITLE
Update to allow using ractive 0.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	},
 	"dependencies": {
 		"compilify": "~0.1.0",
-		"ractive": "~0.4"
+		"ractive": "0.x"
 	},
 	"devDependencies": {
 		"mocha": "~1.19.0",


### PR DESCRIPTION
the ractive dependency is listed as `~0.4`. This is equivalent to `0.4.x` according to [semver](https://www.npmjs.org/doc/misc/semver.html), making the new [0.5.5 version](https://www.npmjs.org/package/ractive) not available to ractivate.

This changes it to `0.x`. It should be fairly reasonable to expect that `Ractive.parse()` is more-or-less guaranteed to be the same-ish before `1.0.0`.

(Thanks for this package btw!)
