### PR TITLE
Use ractive from the parent module instead of directly depending on it.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,16 @@
 'use strict'
 
 var compilify = require( 'compilify' )
-var Ractive = require( 'ractive' )
+
+try {
+	var Ractive = require( 'ractive' )
+} catch ( e ) {
+	if ( e.code === 'MODULE_NOT_FOUND' ) {
+		throw new Error( 'Module "ractive" required by "ractivate" is not found. Please run: npm install ractive --save' )
+	}
+
+	throw e;
+}
 
 var defaultExtensions = [ '.html' ]
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
 		"url": "git://github.com/jrajav/ractivate.git"
 	},
 	"dependencies": {
-		"compilify": "~0.1.0",
-		"ractive": "0.x"
+		"compilify": "~0.1.0"
 	},
 	"devDependencies": {
 		"mocha": "~1.19.0",
@@ -17,7 +16,8 @@
 		"browserify": "~4.1.5",
 		"browser-run": "~0.2.2",
 		"eslint": "~0.6.2",
-		"through": "~2.3.4"
+		"through": "~2.3.4",
+		"ractive": "0.x"
 	},
 	"scripts": {
 		"test": "node_modules/eslint/bin/eslint.js . && node_modules/mocha/bin/mocha test/test.js"


### PR DESCRIPTION
Using 0.x doesn't solve the issues of version mismatch, as the parent may be depending on an older version, or eventually ractive may go 1.0.

Instead, by not including it in the dependencies we'll depend directly on whatever version of ractive the module using ractivate is using.
